### PR TITLE
A user can create an exercise from the workout form when updating an existing workout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "formik": "^1.5.7",
     "graphql-request": "^1.8.2",
     "moment": "^2.24.0",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dnd": "^7.4.5",
     "react-dnd-html5-backend": "^7.4.4",

--- a/src/components/Workout/Form/Form.js
+++ b/src/components/Workout/Form/Form.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {FieldArray} from 'formik'
 import {MultistepWizard} from '../../UI/MultistepWizard'
 import {Input} from '../../UI/Input'
@@ -79,4 +80,14 @@ export const WorkoutForm = ({
       </MultistepWizard.Page>
     </MultistepWizard>
   )
+}
+
+WorkoutForm.propTypes = {
+  workout: PropTypes.object,
+  submitText: PropTypes.string.isRequired,
+  history: PropTypes.object.isRequired,
+  redirectTo: PropTypes.string.isRequired,
+  fetchExercises: PropTypes.func.isRequired,
+  createExercise: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired
 }

--- a/src/containers/UpdateWorkout.js
+++ b/src/containers/UpdateWorkout.js
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
 import {updateWorkout} from '../api/workout'
-import {fetchExercises} from '../api/exercise'
+import {fetchExercises, createExercise} from '../api/exercise'
 import {getWorkout} from '../state/workout/workout-action-creators'
 import {getWorkout as getWorkoutSelector, isLoading} from '../state/workout/workout-selectors'
 import {Loading} from '../components/Loading'
@@ -13,6 +13,7 @@ export const UpdateWorkout = ({
   workoutId,
   updateWorkout,
   fetchExercises,
+  createExercise,
   workout,
   isLoading,
   getWorkout
@@ -33,6 +34,7 @@ export const UpdateWorkout = ({
             history={history}
             redirectTo={`/workouts/${workoutId}`}
             fetchExercises={fetchExercises}
+            createExercise={createExercise}
             handleSubmit={updateWorkout}/>}
     </>
   )
@@ -45,6 +47,7 @@ const mapStateToProps = (state, {match, history}) => {
     workoutId,
     updateWorkout,
     fetchExercises,
+    createExercise,
     workout: getWorkoutSelector(state, workoutId),
     isLoading: isLoading(state),
   }

--- a/src/containers/__tests__/UpdateWorkout.spec.js
+++ b/src/containers/__tests__/UpdateWorkout.spec.js
@@ -18,6 +18,7 @@ describe('<UpdateWorkout/>', () => {
       workout: Factory.build('workout', {id: 1}),
       isLoading: false,
       fetchExercises: () => {},
+      createExercise: () => {},
       updateWorkout: () => {},
       getWorkout: sinon.spy()
     }
@@ -32,6 +33,7 @@ describe('<UpdateWorkout/>', () => {
     expect(wrapper.find(WorkoutForm).props().history).to.be.eql(props.history)
     expect(wrapper.find(WorkoutForm).props().redirectTo).to.be.equal(`/workouts/${props.workoutId}`)
     expect(wrapper.find(WorkoutForm).props().fetchExercises).to.be.equal(props.fetchExercises)
+    expect(wrapper.find(WorkoutForm).props().createExercise).to.be.equal(props.createExercise)
     expect(wrapper.find(WorkoutForm).props().handleSubmit).to.be.equal(props.updateWorkout)
   })
 


### PR DESCRIPTION
This PR fixes a bug which didn't allow a user to create a new exercise from the workout form. The bug happened because the `createExercise` prop was undefined. Note from now on all components must specify their `PropTypes` to avoid this type of issues in the future.